### PR TITLE
Domzippilli/add flatten flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ version of [Terraform PR #3170](https://github.com/hashicorp/terraform/pull/3170
 
 ## Supported Terraform Version
 
-Tested up to Terraform v0.11.7
+Tested up to Terraform v0.11.10
 
 ## Installation
 

--- a/converter/converter.go
+++ b/converter/converter.go
@@ -2,10 +2,11 @@ package converter
 
 import (
 	"os"
+
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func ConvertPlan(planfile string) (output, error) {
+func ConvertPlan(planfile string, flatten bool) (output, error) {
 	f, err := os.Open(planfile)
 	if err != nil {
 		return nil, err
@@ -19,7 +20,7 @@ func ConvertPlan(planfile string) (output, error) {
 
 	diff := output{}
 	for _, v := range plan.Diff.Modules {
-		convertModuleDiff(diff, v)
+		convertModuleDiff(diff, v, flatten)
 	}
 
 	return diff, nil

--- a/converter/util.go
+++ b/converter/util.go
@@ -39,6 +39,11 @@ func convertModuleDiff(out output, diff *terraform.ModuleDiff, flat bool) {
 			}
 
 			flatName.WriteString(k)
+
+			if len(diff.Path) == 1 {
+				// only transcribe destroy only for root module, all other modules are ignored in the flattened version
+				insert(out, diff.Path, "destroy", diff.Destroy)
+			}
 			instanceName = []string{flatName.String()}
 		} else {
 			insert(out, diff.Path, "destroy", diff.Destroy)

--- a/converter/util.go
+++ b/converter/util.go
@@ -26,10 +26,11 @@ func insert(out output, path []string, key string, value interface{}) {
 }
 
 func convertModuleDiff(out output, diff *terraform.ModuleDiff, flat bool) {
+	var flatName strings.Builder
 	for k, v := range diff.Resources {
 		var instanceName []string
 		if flat {
-			var flatName strings.Builder
+			flatName.Reset()
 
 			if len(diff.Path) > 1 {
 				// slice [1:] to omit "Root" string

--- a/tfjson.go
+++ b/tfjson.go
@@ -24,18 +24,31 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"os"
-	"github.com/alshabib/tfjson/converter"
+
+	"github.com/morgante/tfjson/converter"
 )
 
 func main() {
-	if len(os.Args) != 2 {
-		fmt.Fprintln(os.Stderr, "usage: tfjson terraform.tfplan")
+	var flatten bool
+
+	flag.BoolVar(&flatten, "flatten", false, "Specify whether to flatten the JSON output by prepending module names to instance names instead of making the instances child values.")
+
+	flag.Usage = func() {
+		fmt.Fprintln(os.Stderr, "usage: tfjson [OPTIONS] planfile.tfplan")
+		flag.CommandLine.PrintDefaults()
+	}
+
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		flag.Usage()
 		os.Exit(1)
 	}
 
-	j, err := tfjson(os.Args[1])
+	j, err := tfjson(flag.Args()[0], flatten)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
@@ -44,9 +57,8 @@ func main() {
 	fmt.Println(j)
 }
 
-
-func tfjson(planfile string) (string, error) {
-	diff, err := converter.ConvertPlan(planfile)
+func tfjson(planfile string, flatten bool) (string, error) {
+	diff, err := converter.ConvertPlan(planfile, flatten)
 
 	if err != nil {
 		return "", err
@@ -59,5 +71,3 @@ func tfjson(planfile string) (string, error) {
 
 	return string(j), nil
 }
-
-

--- a/tfjson_test.go
+++ b/tfjson_test.go
@@ -86,6 +86,7 @@ const expected = `{
 }`
 
 const expectedFlat = `{
+    "destroy": false,
     "google_compute_network.test": {
         "auto_create_subnetworks": "true",
         "destroy": false,
@@ -154,7 +155,7 @@ func TestMain(m *testing.M) {
 
 	planPath = filepath.Join(dir, "terraform.tfplan")
 	run("terraform", "get", dir)
-	run("terraform", "init")
+	run("terraform", "init", dir)
 	run("terraform", "plan", "-out="+planPath, dir)
 
 	os.Exit(m.Run())

--- a/tfjson_test.go
+++ b/tfjson_test.go
@@ -32,85 +32,113 @@ import (
 )
 
 const mainTF = `
-provider "google" {
-	region = "us-central1"
-  }
-  
-  resource "google_compute_network" "test" {
-	name = "test"
-  }
-  
-  module "inner" {
-	source = "./inner"
-  }	
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+}
+
+module "inner" {
+  source = "./inner"
+}
 `
 
 const innerTF = `
-resource "google_compute_subnetwork" "subnet0" {
-	name          = "testsub"
-	ip_cidr_range = "10.0.0.0/24"
-	network       = "test"
-  }  
+resource "aws_vpc" "inner" {
+  cidr_block = "10.0.0.0/8"
+}
 `
 
 const expected = `{
-    "destroy": false,
-    "google_compute_network.test": {
-        "auto_create_subnetworks": "true",
+    "aws_vpc.main": {
+        "arn": "",
+        "assign_generated_ipv6_cidr_block": "false",
+        "cidr_block": "10.0.0.0/16",
+        "default_network_acl_id": "",
+        "default_route_table_id": "",
+        "default_security_group_id": "",
         "destroy": false,
         "destroy_tainted": false,
-        "gateway_ipv4": "",
+        "dhcp_options_id": "",
+        "enable_classiclink": "",
+        "enable_classiclink_dns_support": "",
+        "enable_dns_hostnames": "",
+        "enable_dns_support": "true",
         "id": "",
-        "name": "test",
-        "project": "",
-        "routing_mode": "",
-        "self_link": ""
+        "instance_tenancy": "default",
+        "ipv6_association_id": "",
+        "ipv6_cidr_block": "",
+        "main_route_table_id": ""
     },
+    "destroy": false,
     "inner": {
-        "destroy": false,
-        "google_compute_subnetwork.subnet0": {
-            "creation_timestamp": "",
+        "aws_vpc.inner": {
+            "arn": "",
+            "assign_generated_ipv6_cidr_block": "false",
+            "cidr_block": "10.0.0.0/8",
+            "default_network_acl_id": "",
+            "default_route_table_id": "",
+            "default_security_group_id": "",
             "destroy": false,
             "destroy_tainted": false,
-            "fingerprint": "",
-            "gateway_address": "",
+            "dhcp_options_id": "",
+            "enable_classiclink": "",
+            "enable_classiclink_dns_support": "",
+            "enable_dns_hostnames": "",
+            "enable_dns_support": "true",
             "id": "",
-            "ip_cidr_range": "10.0.0.0/24",
-            "name": "testsub",
-            "network": "test",
-            "project": "",
-            "secondary_ip_range.#": "",
-            "self_link": ""
-        }
+            "instance_tenancy": "default",
+            "ipv6_association_id": "",
+            "ipv6_cidr_block": "",
+            "main_route_table_id": ""
+        },
+        "destroy": false
     }
 }`
 
 const expectedFlat = `{
-    "destroy": false,
-    "google_compute_network.test": {
-        "auto_create_subnetworks": "true",
+    "aws_vpc.main": {
+        "arn": "",
+        "assign_generated_ipv6_cidr_block": "false",
+        "cidr_block": "10.0.0.0/16",
+        "default_network_acl_id": "",
+        "default_route_table_id": "",
+        "default_security_group_id": "",
         "destroy": false,
         "destroy_tainted": false,
-        "gateway_ipv4": "",
+        "dhcp_options_id": "",
+        "enable_classiclink": "",
+        "enable_classiclink_dns_support": "",
+        "enable_dns_hostnames": "",
+        "enable_dns_support": "true",
         "id": "",
-        "name": "test",
-        "project": "",
-        "routing_mode": "",
-        "self_link": ""
+        "instance_tenancy": "default",
+        "ipv6_association_id": "",
+        "ipv6_cidr_block": "",
+        "main_route_table_id": ""
     },
-    "inner.google_compute_subnetwork.subnet0": {
-        "creation_timestamp": "",
+    "destroy": false,
+    "inner.aws_vpc.inner": {
+        "arn": "",
+        "assign_generated_ipv6_cidr_block": "false",
+        "cidr_block": "10.0.0.0/8",
+        "default_network_acl_id": "",
+        "default_route_table_id": "",
+        "default_security_group_id": "",
         "destroy": false,
         "destroy_tainted": false,
-        "fingerprint": "",
-        "gateway_address": "",
+        "dhcp_options_id": "",
+        "enable_classiclink": "",
+        "enable_classiclink_dns_support": "",
+        "enable_dns_hostnames": "",
+        "enable_dns_support": "true",
         "id": "",
-        "ip_cidr_range": "10.0.0.0/24",
-        "name": "testsub",
-        "network": "test",
-        "project": "",
-        "secondary_ip_range.#": "",
-        "self_link": ""
+        "instance_tenancy": "default",
+        "ipv6_association_id": "",
+        "ipv6_cidr_block": "",
+        "main_route_table_id": ""
     }
 }`
 


### PR DESCRIPTION
Changes:

* Adds flag parsing using `flag`, including `-flatten` flag
* Adds flattening logic, wherein the module names are prepended to the instance name instead of making the instances children of the modules in the tree
* Update tests to include both flat and hierarchical cases

Also, the test TF was changed to use GCP as it was more convenient than trying to get AWS account + creds to run a plan; feel free to revert if you have an AWS account handy to run the test & tweak.